### PR TITLE
feature(#3): 모달 기능 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "tailwindcss": "^4.1.11",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.35.1",
-    "vite": "^7.0.4"
+    "vite": "^7.0.4",
+    "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ importers:
         version: 9.32.0
       '@tailwindcss/vite':
         specifier: ^4.1.11
-        version: 4.1.11(vite@7.0.6(jiti@2.5.1)(lightningcss@1.30.1))
+        version: 4.1.11(vite@7.0.6(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1))
       '@types/react':
         specifier: ^19.1.8
         version: 19.1.9
@@ -29,7 +29,7 @@ importers:
         version: 19.1.7(@types/react@19.1.9)
       '@vitejs/plugin-react-swc':
         specifier: ^3.10.2
-        version: 3.11.0(vite@7.0.6(jiti@2.5.1)(lightningcss@1.30.1))
+        version: 3.11.0(vite@7.0.6(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1))
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -62,7 +62,10 @@ importers:
         version: 8.39.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)
       vite:
         specifier: ^7.0.4
-        version: 7.0.6(jiti@2.5.1)(lightningcss@1.30.1)
+        version: 7.0.6(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)
+      vite-tsconfig-paths:
+        specifier: ^5.1.4
+        version: 5.1.4(typescript@5.8.3)(vite@7.0.6(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1))
 
 packages:
 
@@ -587,6 +590,9 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/node@24.3.0':
+    resolution: {integrity: sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==}
+
   '@types/react-dom@19.1.7':
     resolution: {integrity: sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==}
     peerDependencies:
@@ -870,6 +876,9 @@ packages:
   globals@16.3.0:
     resolution: {integrity: sha512-bqWEnJ1Nt3neqx2q5SFfGS8r/ahumIakg3HcwtNlrVlwXIeNumWn/c7Pn/wKzGhf6SaW6H6uWXLqC30STCMchQ==}
     engines: {node: '>=18'}
+
+  globrex@0.1.2:
+    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -1243,6 +1252,16 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
+  tsconfck@3.1.6:
+    resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -1259,8 +1278,19 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  undici-types@7.10.0:
+    resolution: {integrity: sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==}
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  vite-tsconfig-paths@5.1.4:
+    resolution: {integrity: sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==}
+    peerDependencies:
+      vite: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
 
   vite@7.0.6:
     resolution: {integrity: sha512-MHFiOENNBd+Bd9uvc8GEsIzdkn1JxMmEeYX35tI3fv0sJBUTfW5tQsoaOwuY4KhBI09A3dUJ/DXf2yxPVPUceg==}
@@ -1669,16 +1699,21 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.1.11
       '@tailwindcss/oxide-win32-x64-msvc': 4.1.11
 
-  '@tailwindcss/vite@4.1.11(vite@7.0.6(jiti@2.5.1)(lightningcss@1.30.1))':
+  '@tailwindcss/vite@4.1.11(vite@7.0.6(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1))':
     dependencies:
       '@tailwindcss/node': 4.1.11
       '@tailwindcss/oxide': 4.1.11
       tailwindcss: 4.1.11
-      vite: 7.0.6(jiti@2.5.1)(lightningcss@1.30.1)
+      vite: 7.0.6(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)
 
   '@types/estree@1.0.8': {}
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/node@24.3.0':
+    dependencies:
+      undici-types: 7.10.0
+    optional: true
 
   '@types/react-dom@19.1.7(@types/react@19.1.9)':
     dependencies:
@@ -1781,11 +1816,11 @@ snapshots:
       '@typescript-eslint/types': 8.39.0
       eslint-visitor-keys: 4.2.1
 
-  '@vitejs/plugin-react-swc@3.11.0(vite@7.0.6(jiti@2.5.1)(lightningcss@1.30.1))':
+  '@vitejs/plugin-react-swc@3.11.0(vite@7.0.6(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@swc/core': 1.13.3
-      vite: 7.0.6(jiti@2.5.1)(lightningcss@1.30.1)
+      vite: 7.0.6(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)
     transitivePeerDependencies:
       - '@swc/helpers'
 
@@ -2027,6 +2062,8 @@ snapshots:
   globals@14.0.0: {}
 
   globals@16.3.0: {}
+
+  globrex@0.1.2: {}
 
   graceful-fs@4.2.11: {}
 
@@ -2294,6 +2331,10 @@ snapshots:
     dependencies:
       typescript: 5.8.3
 
+  tsconfck@3.1.6(typescript@5.8.3):
+    optionalDependencies:
+      typescript: 5.8.3
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -2311,11 +2352,25 @@ snapshots:
 
   typescript@5.8.3: {}
 
+  undici-types@7.10.0:
+    optional: true
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
 
-  vite@7.0.6(jiti@2.5.1)(lightningcss@1.30.1):
+  vite-tsconfig-paths@5.1.4(typescript@5.8.3)(vite@7.0.6(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)):
+    dependencies:
+      debug: 4.4.1
+      globrex: 0.1.2
+      tsconfck: 3.1.6(typescript@5.8.3)
+    optionalDependencies:
+      vite: 7.0.6(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  vite@7.0.6(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1):
     dependencies:
       esbuild: 0.25.8
       fdir: 6.4.6(picomatch@4.0.3)
@@ -2324,6 +2379,7 @@ snapshots:
       rollup: 4.46.2
       tinyglobby: 0.2.14
     optionalDependencies:
+      '@types/node': 24.3.0
       fsevents: 2.3.3
       jiti: 2.5.1
       lightningcss: 1.30.1

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,11 @@
-import { Button } from './components/Button';
-import { Alerts } from './components/modals/Alerts';
-import { ConfirmDialog } from './components/modals/ConfirmDialog';
-import { SimpleDialog } from './components/modals/SimpleDialog';
-import { ToggleMenus as SimpleMenus } from './components/modals/ToggleMenus';
-import { useToggle } from './hooks/useToggle';
+import {
+  Alerts,
+  ConfirmDialog,
+  SimpleDialog,
+  SimpleMenus,
+} from '@components/modals';
+import { Button } from '@components/Button';
+import { useToggle } from '@hooks/useToggle';
 
 function App() {
   const [isAlertsOpen, toggleAlerts, , closeAlerts] = useToggle(false);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,37 @@
+import { Button } from './components/Button';
 import { Alerts } from './components/modals/Alerts';
 import { ConfirmDialog } from './components/modals/ConfirmDialog';
 import { SimpleDialog } from './components/modals/SimpleDialog';
-import { ToggleMenus } from './components/modals/ToggleMenus';
+import { ToggleMenus as SimpleMenus } from './components/modals/ToggleMenus';
+import { useToggle } from './hooks/useToggle';
 
 function App() {
+  const [isAlertsOpen, toggleAlerts, , closeAlerts] = useToggle(false);
+  const [isTitleDialogOpen, toggleTitleDialog, , closeTitleDialog] =
+    useToggle(false);
+  const [isLocationDialogOpen, toggleLocationDialog, , closeLocationDialog] =
+    useToggle(false);
+  const [isSimpleDialogOpen, toggleSimpleDialog, , closeSimpleDialog] =
+    useToggle(false);
+  const [isSimpleMenusOpen, toggleSimpleMenus, , closeSimpleMenus] =
+    useToggle(false);
+
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center gap-6 bg-gray-100">
+    <div className="flex min-h-screen items-center justify-center gap-6 bg-gray-100">
+      <Button onClick={toggleAlerts}>삭제</Button>
+      <Button onClick={toggleTitleDialog}>제목 선택</Button>
+      <Button onClick={toggleLocationDialog}>위치 정보 동의</Button>
+      <Button onClick={toggleSimpleDialog}>메뉴 선택</Button>
+      <Button onClick={toggleSimpleMenus}>더보기</Button>
+
       <Alerts
+        isModalOpen={isAlertsOpen}
+        closeModal={closeAlerts}
         message="초안을 삭제하시겠습니까?"
         actions={[
           {
             label: '취소',
-            onClick: () => confirm('취소'),
+            onClick: closeAlerts,
           },
           {
             label: '삭제',
@@ -19,8 +39,11 @@ function App() {
           },
         ]}
       />
+
       <ConfirmDialog
         title="Title"
+        isModalOpen={isTitleDialogOpen}
+        closeModal={closeTitleDialog}
         content={
           <ul className="flex max-h-[10rem] w-[12rem] flex-col overflow-y-auto">
             <li className="flex gap-2 py-2">
@@ -40,21 +63,24 @@ function App() {
         actions={[
           {
             label: '취소',
-            onClick: () => confirm('취소'),
+            onClick: closeTitleDialog,
           },
           {
-            label: '동의',
-            onClick: () => confirm('동의'),
+            label: '선택',
+            onClick: () => confirm('선택'),
           },
         ]}
       />
+
       <ConfirmDialog
         title="위치 정보 동의"
+        isModalOpen={isLocationDialogOpen}
+        closeModal={closeLocationDialog}
         content="Google에서 앱의 위치 파악을 지원하도록 동의하시겠습니까?"
         actions={[
           {
             label: '취소',
-            onClick: () => confirm('취소'),
+            onClick: closeLocationDialog,
           },
           {
             label: '동의',
@@ -62,7 +88,12 @@ function App() {
           },
         ]}
       />
-      <SimpleDialog title="계정 설정">
+
+      <SimpleDialog
+        title="계정 설정"
+        isModalOpen={isSimpleDialogOpen}
+        closeModal={closeSimpleDialog}
+      >
         <div className="flex items-center gap-3">
           <div className="rounded-full bg-black p-5" />
           <span>username@gmail.com</span>
@@ -76,7 +107,10 @@ function App() {
           <span>username@gmail.com</span>
         </div>
       </SimpleDialog>
-      <ToggleMenus
+
+      <SimpleMenus
+        isModalOpen={isSimpleMenusOpen}
+        closeModal={closeSimpleMenus}
         menus={[
           {
             label: '모든 알림 보여주기',

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,8 +23,8 @@ function App() {
       <Button onClick={toggleAlerts}>삭제</Button>
       <Button onClick={toggleTitleDialog}>제목 선택</Button>
       <Button onClick={toggleLocationDialog}>위치 정보 동의</Button>
-      <Button onClick={toggleSimpleDialog}>메뉴 선택</Button>
-      <Button onClick={toggleSimpleMenus}>더보기</Button>
+      <Button onClick={toggleSimpleDialog}>계정 선택</Button>
+      <Button onClick={toggleSimpleMenus}>알림 권한</Button>
 
       <Alerts
         isModalOpen={isAlertsOpen}
@@ -92,7 +92,7 @@ function App() {
       />
 
       <SimpleDialog
-        title="계정 설정"
+        title="계정 목록"
         isModalOpen={isSimpleDialogOpen}
         closeModal={closeSimpleDialog}
       >

--- a/src/components/ModalOverlay.tsx
+++ b/src/components/ModalOverlay.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import clsx from 'clsx';
-import { Button } from '../Button';
-import type { ModalProps } from './types';
+import { Button } from './Button';
+import type { ModalProps } from './modals';
 
 interface ModalOverlayProps extends ModalProps {
   children: ReactNode;

--- a/src/components/ModalOverlay.tsx
+++ b/src/components/ModalOverlay.tsx
@@ -1,9 +1,13 @@
-import type { ReactNode } from 'react';
-import clsx from 'clsx';
+import { type ReactNode } from 'react';
+
+import {
+  modalOverlayClass,
+  modalSectionClass,
+  type ModalProps,
+} from '@components/modals';
 import { Button } from '@components/Button';
-import type { ModalProps } from '@components/modals';
-import { useOutsideClick } from '@hooks/useOutsideClick';
 import { useEscapeKey } from '@hooks/useEscapeKey';
+import { useOutsideClick } from '@hooks/useOutsideClick';
 
 interface ModalOverlayProps extends ModalProps {
   children: ReactNode;
@@ -21,20 +25,6 @@ export function ModalOverlay({
     closeModal,
   });
   const { modalRef } = useOutsideClick(closeModal);
-
-  const modalOverlayClass = (isOpen: boolean) =>
-    clsx(
-      'modal-overlay',
-      isOpen
-        ? 'opacity-50 pointer-events-auto'
-        : 'opacity-0 pointer-events-none'
-    );
-
-  const modalSectionClass = (isOpen: boolean) =>
-    clsx(
-      'modal-section',
-      isOpen ? 'scale-100 opacity-100' : 'pointer-events-none opacity-0'
-    );
 
   return (
     <>

--- a/src/components/ModalOverlay.tsx
+++ b/src/components/ModalOverlay.tsx
@@ -1,7 +1,8 @@
 import type { ReactNode } from 'react';
 import clsx from 'clsx';
-import { Button } from './Button';
-import type { ModalProps } from './modals';
+import { Button } from '@components/Button';
+import type { ModalProps } from '@components/modals';
+import { useOutsideClick } from '@hooks/useOutsideClick';
 
 interface ModalOverlayProps extends ModalProps {
   children: ReactNode;
@@ -9,11 +10,13 @@ interface ModalOverlayProps extends ModalProps {
 }
 
 export function ModalOverlay({
-  isModalOpen,
-  closeModal,
   children,
   showCloseBtn = true,
+  isModalOpen,
+  closeModal,
 }: ModalOverlayProps) {
+  const { modalRef } = useOutsideClick(closeModal);
+
   const modalOverlayClass = (isOpen: boolean) =>
     clsx(
       'modal-overlay',
@@ -32,7 +35,7 @@ export function ModalOverlay({
     <>
       <div className={modalOverlayClass(isModalOpen)} />
       <div className={modalSectionClass(isModalOpen)}>
-        <div className="modal-content">
+        <div className="modal-content" ref={modalRef}>
           {showCloseBtn && (
             <Button
               variant="transparent"

--- a/src/components/ModalOverlay.tsx
+++ b/src/components/ModalOverlay.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import { Button } from '@components/Button';
 import type { ModalProps } from '@components/modals';
 import { useOutsideClick } from '@hooks/useOutsideClick';
+import { useEscapeKey } from '@hooks/useEscapeKey';
 
 interface ModalOverlayProps extends ModalProps {
   children: ReactNode;
@@ -15,6 +16,10 @@ export function ModalOverlay({
   isModalOpen,
   closeModal,
 }: ModalOverlayProps) {
+  const { overlayRef, handleEscapeKey } = useEscapeKey({
+    isModalOpen,
+    closeModal,
+  });
   const { modalRef } = useOutsideClick(closeModal);
 
   const modalOverlayClass = (isOpen: boolean) =>
@@ -33,7 +38,12 @@ export function ModalOverlay({
 
   return (
     <>
-      <div className={modalOverlayClass(isModalOpen)} />
+      <div
+        ref={overlayRef}
+        tabIndex={0}
+        onKeyDown={handleEscapeKey}
+        className={modalOverlayClass(isModalOpen)}
+      />
       <div className={modalSectionClass(isModalOpen)}>
         <div className="modal-content" ref={modalRef}>
           {showCloseBtn && (

--- a/src/components/modals/Alerts.tsx
+++ b/src/components/modals/Alerts.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@components/Button';
-import { ModalOverlay } from '@components/ModalOverlay';
+import { ModalOverlay } from './ModalOverlay';
 import type { Action, ModalProps } from './types';
 
 interface AlertsProps extends ModalProps {

--- a/src/components/modals/Alerts.tsx
+++ b/src/components/modals/Alerts.tsx
@@ -1,16 +1,26 @@
 import { Button } from '../Button';
 import { ModalOverlay } from './ModalOverlay';
-import type { Action } from './types';
+import type { Action, ModalProps } from './types';
 
-interface AlertsProps {
+interface AlertsProps extends ModalProps {
   title?: string;
   message: string;
   actions?: Action[];
 }
 
-export function Alerts({ title = '', message, actions }: AlertsProps) {
+export function Alerts({
+  title = '',
+  message,
+  actions,
+  isModalOpen,
+  closeModal,
+}: AlertsProps) {
   return (
-    <ModalOverlay showCloseBtn={false}>
+    <ModalOverlay
+      isModalOpen={isModalOpen}
+      closeModal={closeModal}
+      showCloseBtn={false}
+    >
       <div className="section">
         <div className="title">{title}</div>
         <span className="content">{message}</span>

--- a/src/components/modals/Alerts.tsx
+++ b/src/components/modals/Alerts.tsx
@@ -1,5 +1,5 @@
-import { Button } from '../Button';
-import { ModalOverlay } from './ModalOverlay';
+import { Button } from '@components/Button';
+import { ModalOverlay } from '@components/ModalOverlay';
 import type { Action, ModalProps } from './types';
 
 interface AlertsProps extends ModalProps {

--- a/src/components/modals/ConfirmDialog.tsx
+++ b/src/components/modals/ConfirmDialog.tsx
@@ -1,17 +1,23 @@
 import type { ReactNode } from 'react';
-import { ModalOverlay } from './ModalOverlay';
 import { Button } from '../Button';
-import type { Action } from './types';
+import { ModalOverlay } from './ModalOverlay';
+import type { Action, ModalProps } from './types';
 
-interface ConfirmDialogProps {
+interface ConfirmDialogProps extends ModalProps {
   title: string;
   content: ReactNode;
   actions?: Action[];
 }
 
-export function ConfirmDialog({ title, content, actions }: ConfirmDialogProps) {
+export function ConfirmDialog({
+  title,
+  content,
+  actions,
+  isModalOpen,
+  closeModal,
+}: ConfirmDialogProps) {
   return (
-    <ModalOverlay>
+    <ModalOverlay isModalOpen={isModalOpen} closeModal={closeModal}>
       <div className="section">
         <div className="title">{title}</div>
         <div className="content">{content}</div>

--- a/src/components/modals/ConfirmDialog.tsx
+++ b/src/components/modals/ConfirmDialog.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
-import { Button } from '../Button';
-import { ModalOverlay } from './ModalOverlay';
+import { Button } from '@components/Button';
+import { ModalOverlay } from '@components/ModalOverlay';
 import type { Action, ModalProps } from './types';
 
 interface ConfirmDialogProps extends ModalProps {

--- a/src/components/modals/ConfirmDialog.tsx
+++ b/src/components/modals/ConfirmDialog.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import { Button } from '@components/Button';
-import { ModalOverlay } from '@components/ModalOverlay';
+import { ModalOverlay } from './ModalOverlay';
 import type { Action, ModalProps } from './types';
 
 interface ConfirmDialogProps extends ModalProps {

--- a/src/components/modals/ModalOverlay.tsx
+++ b/src/components/modals/ModalOverlay.tsx
@@ -1,13 +1,11 @@
 import { type ReactNode } from 'react';
 
-import {
-  modalOverlayClass,
-  modalSectionClass,
-  type ModalProps,
-} from '@components/modals';
 import { Button } from '@components/Button';
 import { useEscapeKey } from '@hooks/useEscapeKey';
 import { useOutsideClick } from '@hooks/useOutsideClick';
+
+import { modalOverlayClass, modalSectionClass } from './modalClass';
+import type { ModalProps } from './types';
 
 interface ModalOverlayProps extends ModalProps {
   children: ReactNode;

--- a/src/components/modals/ModalOverlay.tsx
+++ b/src/components/modals/ModalOverlay.tsx
@@ -24,14 +24,15 @@ export function ModalOverlay({
 
   return (
     <>
-      <div className={modalOverlayClass(isModalOpen)} />
+      <div className={modalOverlayClass(isModalOpen)} aria-hidden />
       <div className={modalSectionClass(isModalOpen)}>
-        <div className="modal-content" ref={modalRef}>
+        <div className="modal-content" ref={modalRef} role="dialog">
           {showCloseBtn && (
             <Button
               variant="transparent"
               className="absolute top-4 right-2"
               onClick={closeModal}
+              aria-label="Close"
             >
               X
             </Button>

--- a/src/components/modals/ModalOverlay.tsx
+++ b/src/components/modals/ModalOverlay.tsx
@@ -18,20 +18,13 @@ export function ModalOverlay({
   isModalOpen,
   closeModal,
 }: ModalOverlayProps) {
-  const { overlayRef, handleEscapeKey } = useEscapeKey({
-    isModalOpen,
-    closeModal,
-  });
+  useEscapeKey({ isModalOpen, onEscape: closeModal });
+
   const { modalRef } = useOutsideClick(closeModal);
 
   return (
     <>
-      <div
-        ref={overlayRef}
-        tabIndex={0}
-        onKeyDown={handleEscapeKey}
-        className={modalOverlayClass(isModalOpen)}
-      />
+      <div className={modalOverlayClass(isModalOpen)} />
       <div className={modalSectionClass(isModalOpen)}>
         <div className="modal-content" ref={modalRef}>
           {showCloseBtn && (

--- a/src/components/modals/ModalOverlay.tsx
+++ b/src/components/modals/ModalOverlay.tsx
@@ -1,27 +1,50 @@
-import { Button } from '../Button';
 import type { ReactNode } from 'react';
+import clsx from 'clsx';
+import { Button } from '../Button';
+import type { ModalProps } from './types';
 
-interface ModalOverlayProps {
+interface ModalOverlayProps extends ModalProps {
   children: ReactNode;
   showCloseBtn?: boolean;
 }
 
 export function ModalOverlay({
+  isModalOpen,
+  closeModal,
   children,
   showCloseBtn = true,
 }: ModalOverlayProps) {
+  const modalOverlayClass = (isOpen: boolean) =>
+    clsx(
+      'modal-overlay',
+      isOpen
+        ? 'opacity-50 pointer-events-auto'
+        : 'opacity-0 pointer-events-none'
+    );
+
+  const modalSectionClass = (isOpen: boolean) =>
+    clsx(
+      'modal-section',
+      isOpen ? 'scale-100 opacity-100' : 'pointer-events-none opacity-0'
+    );
+
   return (
-    <div className="modal-overlay">
-      <div className="modal-section">
+    <>
+      <div className={modalOverlayClass(isModalOpen)} />
+      <div className={modalSectionClass(isModalOpen)}>
         <div className="modal-content">
           {showCloseBtn && (
-            <Button variant="transparent" className="absolute top-4 right-2">
+            <Button
+              variant="transparent"
+              className="absolute top-4 right-2"
+              onClick={closeModal}
+            >
               X
             </Button>
           )}
           {children}
         </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/src/components/modals/ModalOverlay.tsx
+++ b/src/components/modals/ModalOverlay.tsx
@@ -12,12 +12,16 @@ export function ModalOverlay({
 }: ModalOverlayProps) {
   return (
     <div className="modal-overlay">
-      {showCloseBtn && (
-        <Button variant="transparent" className="absolute top-4 right-2">
-          X
-        </Button>
-      )}
-      {children}
+      <div className="modal-section">
+        <div className="modal-content">
+          {showCloseBtn && (
+            <Button variant="transparent" className="absolute top-4 right-2">
+              X
+            </Button>
+          )}
+          {children}
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/components/modals/SimpleDialog.tsx
+++ b/src/components/modals/SimpleDialog.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { ModalOverlay } from '@components/ModalOverlay';
+import { ModalOverlay } from './ModalOverlay';
 import type { ModalProps } from './types';
 
 interface SimpleDialogProps extends ModalProps {

--- a/src/components/modals/SimpleDialog.tsx
+++ b/src/components/modals/SimpleDialog.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { ModalOverlay } from './ModalOverlay';
+import { ModalOverlay } from '@components/ModalOverlay';
 import type { ModalProps } from './types';
 
 interface SimpleDialogProps extends ModalProps {

--- a/src/components/modals/SimpleDialog.tsx
+++ b/src/components/modals/SimpleDialog.tsx
@@ -1,14 +1,24 @@
 import type { ReactNode } from 'react';
 import { ModalOverlay } from './ModalOverlay';
+import type { ModalProps } from './types';
 
-interface SimpleDialogProps {
+interface SimpleDialogProps extends ModalProps {
   title: string;
   children?: ReactNode;
 }
 
-export function SimpleDialog({ title, children }: SimpleDialogProps) {
+export function SimpleDialog({
+  title,
+  children,
+  isModalOpen,
+  closeModal,
+}: SimpleDialogProps) {
   return (
-    <ModalOverlay showCloseBtn={false}>
+    <ModalOverlay
+      showCloseBtn={false}
+      isModalOpen={isModalOpen}
+      closeModal={closeModal}
+    >
       <div className="section">
         <div className="title">{title}</div>
         {children}

--- a/src/components/modals/SimpleMenus.tsx
+++ b/src/components/modals/SimpleMenus.tsx
@@ -1,15 +1,15 @@
-import { ModalOverlay } from './ModalOverlay';
+import { ModalOverlay } from '@components/ModalOverlay';
 import type { Action, ModalProps } from './types';
 
-interface ToggleMenusProps extends ModalProps {
+interface SimpleMenusProps extends ModalProps {
   menus: Action[];
 }
 
-export function ToggleMenus({
+export function SimpleMenus({
   menus,
   isModalOpen,
   closeModal,
-}: ToggleMenusProps) {
+}: SimpleMenusProps) {
   return (
     <ModalOverlay
       showCloseBtn={false}

--- a/src/components/modals/SimpleMenus.tsx
+++ b/src/components/modals/SimpleMenus.tsx
@@ -1,4 +1,4 @@
-import { ModalOverlay } from '@components/ModalOverlay';
+import { ModalOverlay } from './ModalOverlay';
 import type { Action, ModalProps } from './types';
 
 interface SimpleMenusProps extends ModalProps {

--- a/src/components/modals/ToggleMenus.tsx
+++ b/src/components/modals/ToggleMenus.tsx
@@ -1,13 +1,21 @@
 import { ModalOverlay } from './ModalOverlay';
-import type { Action } from './types';
+import type { Action, ModalProps } from './types';
 
-interface ToggleMenusProps {
+interface ToggleMenusProps extends ModalProps {
   menus: Action[];
 }
 
-export function ToggleMenus({ menus }: ToggleMenusProps) {
+export function ToggleMenus({
+  menus,
+  isModalOpen,
+  closeModal,
+}: ToggleMenusProps) {
   return (
-    <ModalOverlay showCloseBtn={false}>
+    <ModalOverlay
+      showCloseBtn={false}
+      isModalOpen={isModalOpen}
+      closeModal={closeModal}
+    >
       <ul>
         {menus?.map(({ label, onClick }: Action) => (
           <li key={label} className="menus" onClick={onClick}>

--- a/src/components/modals/index.ts
+++ b/src/components/modals/index.ts
@@ -1,5 +1,6 @@
 export * from './Alerts';
 export * from './ConfirmDialog';
+export * from './ModalOverlay';
 export * from './SimpleDialog';
 export * from './SimpleMenus';
 

--- a/src/components/modals/index.ts
+++ b/src/components/modals/index.ts
@@ -1,0 +1,5 @@
+export * from './Alerts';
+export * from './ConfirmDialog';
+export * from './SimpleDialog';
+export * from './SimpleMenus';
+export * from './types';

--- a/src/components/modals/index.ts
+++ b/src/components/modals/index.ts
@@ -2,4 +2,6 @@ export * from './Alerts';
 export * from './ConfirmDialog';
 export * from './SimpleDialog';
 export * from './SimpleMenus';
+
 export * from './types';
+export * from './modalClass';

--- a/src/components/modals/modalClass.ts
+++ b/src/components/modals/modalClass.ts
@@ -1,0 +1,13 @@
+import clsx from 'clsx';
+
+export const modalOverlayClass = (isOpen: boolean) =>
+  clsx(
+    'modal-overlay',
+    isOpen ? 'opacity-50 pointer-events-auto' : 'opacity-0 pointer-events-none'
+  );
+
+export const modalSectionClass = (isOpen: boolean) =>
+  clsx(
+    'modal-section',
+    isOpen ? 'scale-100 opacity-100' : 'pointer-events-none opacity-0'
+  );

--- a/src/components/modals/types.ts
+++ b/src/components/modals/types.ts
@@ -2,3 +2,8 @@ export interface Action {
   label: string;
   onClick?: () => void;
 }
+
+export interface ModalProps {
+  isModalOpen: boolean;
+  closeModal: () => void;
+}

--- a/src/components/modals/types.ts
+++ b/src/components/modals/types.ts
@@ -1,3 +1,5 @@
+import type { RefObject } from 'react';
+
 export interface Action {
   label: string;
   onClick?: () => void;
@@ -6,4 +8,5 @@ export interface Action {
 export interface ModalProps {
   isModalOpen: boolean;
   closeModal: () => void;
+  ref?: RefObject<HTMLDivElement | null>;
 }

--- a/src/components/modals/types.ts
+++ b/src/components/modals/types.ts
@@ -1,5 +1,3 @@
-import type { RefObject } from 'react';
-
 export interface Action {
   label: string;
   onClick?: () => void;
@@ -8,5 +6,4 @@ export interface Action {
 export interface ModalProps {
   isModalOpen: boolean;
   closeModal: () => void;
-  ref?: RefObject<HTMLDivElement | null>;
 }

--- a/src/hooks/useEscapeKey.ts
+++ b/src/hooks/useEscapeKey.ts
@@ -1,4 +1,4 @@
-import { useEffect, type KeyboardEvent } from 'react';
+import { useEffect } from 'react';
 
 interface UseEscapeKeyProps {
   isModalOpen: boolean;

--- a/src/hooks/useEscapeKey.ts
+++ b/src/hooks/useEscapeKey.ts
@@ -1,30 +1,22 @@
-import { useEffect, useRef, type KeyboardEvent } from 'react';
+import { useEffect, type KeyboardEvent } from 'react';
 
 interface UseEscapeKeyProps {
   isModalOpen: boolean;
-  closeModal: () => void;
+  onEscape: () => void;
 }
 
-export const useEscapeKey = ({
-  isModalOpen,
-  closeModal,
-}: UseEscapeKeyProps) => {
-  const overlayRef = useRef<HTMLDivElement>(null);
-
-  const handleEscapeKey = (event: KeyboardEvent<HTMLDivElement>) => {
-    if (event.key === 'Escape') {
-      closeModal();
-    }
-  };
-
+export const useEscapeKey = ({ isModalOpen, onEscape }: UseEscapeKeyProps) => {
   useEffect(() => {
-    if (isModalOpen) {
-      overlayRef.current?.focus();
-    }
-  }, [isModalOpen]);
+    if (!isModalOpen) return;
 
-  return {
-    overlayRef,
-    handleEscapeKey,
-  };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onEscape();
+      }
+    };
+
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [isModalOpen, onEscape]);
 };

--- a/src/hooks/useEscapeKey.ts
+++ b/src/hooks/useEscapeKey.ts
@@ -1,0 +1,30 @@
+import { useEffect, useRef, type KeyboardEvent } from 'react';
+
+interface UseEscapeKeyProps {
+  isModalOpen: boolean;
+  closeModal: () => void;
+}
+
+export const useEscapeKey = ({
+  isModalOpen,
+  closeModal,
+}: UseEscapeKeyProps) => {
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  const handleEscapeKey = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape') {
+      closeModal();
+    }
+  };
+
+  useEffect(() => {
+    if (isModalOpen) {
+      overlayRef.current?.focus();
+    }
+  }, [isModalOpen]);
+
+  return {
+    overlayRef,
+    handleEscapeKey,
+  };
+};

--- a/src/hooks/useOutsideClick.ts
+++ b/src/hooks/useOutsideClick.ts
@@ -1,0 +1,18 @@
+import { useEffect, useRef } from 'react';
+
+export const useOutsideClick = (closeModal: () => void) => {
+  const modalRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
+        closeModal();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [closeModal]);
+
+  return { modalRef };
+};

--- a/src/hooks/useToggle.ts
+++ b/src/hooks/useToggle.ts
@@ -1,0 +1,27 @@
+import { useCallback, useState } from 'react';
+
+type UseToggleReturn = readonly [
+  value: boolean,
+  toggle: () => void,
+  setTrue: () => void,
+  setFalse: () => void,
+];
+
+/** 토글 상태를 관리하는 커스텀 훅
+ * @param initialValue 초기 토글 상태 (기본값: false)
+ * @returns
+ * - value: 현재 토글 상태
+ * - toggle: 토글 상태를 반전시키는 함수
+ * - setTrue: 토글 상태를 true로 설정하는 함수
+ * - setFalse: 토글 상태를 false로 설정하는 함수
+ */
+
+export const useToggle = (initialValue: boolean): UseToggleReturn => {
+  const [value, setValue] = useState(initialValue);
+
+  const toggle = useCallback(() => setValue((prev) => !prev), []);
+  const setTrue = useCallback(() => setValue(true), []);
+  const setFalse = useCallback(() => setValue(false), []);
+
+  return [value, toggle, setTrue, setFalse] as const;
+};

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,4 +1,5 @@
 @import 'tailwindcss';
+@import './modal.css';
 
 @theme {
   --color-primary: #155dfc; /* text-blue-600 */
@@ -22,25 +23,4 @@ h2 {
 h3 {
   font-weight: bold;
   font-size: 24px;
-}
-
-@layer components {
-  .modal-overlay {
-    @apply relative rounded-md bg-white shadow-md;
-  }
-  .modal-overlay .section {
-    @apply flex flex-col gap-6 p-7;
-  }
-  .modal-overlay .title {
-    @apply text-lg font-bold;
-  }
-  .modal-overlay .content {
-    @apply block text-gray-700;
-  }
-  .modal-overlay .actions {
-    @apply flex items-center justify-end gap-2 p-3;
-  }
-  .modal-overlay .menus {
-    @apply cursor-pointer bg-gray-100 p-3 pr-10 hover:bg-gray-200;
-  }
 }

--- a/src/styles/modal.css
+++ b/src/styles/modal.css
@@ -1,0 +1,29 @@
+.modal-overlay {
+  @apply fixed inset-0 flex items-center justify-center bg-black;
+  @apply transition duration-300 ease-in-out;
+}
+.modal-section {
+  @apply fixed inset-0 flex scale-95 flex-col items-center justify-center;
+  @apply transform transition duration-300 ease-in-out;
+}
+.modal-content {
+  @apply relative flex flex-col items-center rounded-md bg-white shadow-md;
+}
+
+@layer components {
+  .modal-content .section {
+    @apply flex flex-col gap-6 p-7;
+  }
+  .modal-content .title {
+    @apply text-lg font-bold;
+  }
+  .modal-content .content {
+    @apply block text-gray-700;
+  }
+  .modal-content .actions {
+    @apply flex w-full items-center justify-end gap-2 p-3;
+  }
+  .modal-content .menus {
+    @apply cursor-pointer bg-gray-100 p-3 pr-10 hover:bg-gray-200;
+  }
+}

--- a/src/styles/modal.css
+++ b/src/styles/modal.css
@@ -1,10 +1,10 @@
 .modal-overlay {
-  @apply fixed inset-0 flex items-center justify-center bg-black;
-  @apply transition duration-300 ease-in-out;
+  @apply fixed inset-0 bg-black;
+  @apply transition duration-200 ease-in-out;
 }
 .modal-section {
   @apply fixed inset-0 flex scale-95 flex-col items-center justify-center;
-  @apply transform transition duration-300 ease-in-out;
+  @apply transform transition duration-200 ease-in-out;
 }
 .modal-content {
   @apply relative flex flex-col items-center rounded-md bg-white shadow-md;

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -21,14 +21,8 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true,
-
-    "baseUrl": "./src",
-    "paths": {
-      "@components/*": ["components/*"],
-      "@hooks/*": ["hooks/*"],
-      "@styles/*": ["styles/*"]
-    }
+    "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "extends": "./tsconfig.json"
 }

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -21,7 +21,14 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+
+    "baseUrl": "./src",
+    "paths": {
+      "@components/*": ["components/*"],
+      "@hooks/*": ["hooks/*"],
+      "@styles/*": ["styles/*"]
+    }
   },
   "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,5 +3,13 @@
   "references": [
     { "path": "./tsconfig.app.json" },
     { "path": "./tsconfig.node.json" }
-  ]
+  ],
+  "compilerOptions": {
+    "baseUrl": "./src",
+    "paths": {
+      "@components/*": ["components/*"],
+      "@hooks/*": ["hooks/*"],
+      "@styles/*": ["styles/*"]
+    }
+  }
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -21,5 +21,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts"],
+  "extends": "./tsconfig.json"
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react-swc';
 import tailwind from '@tailwindcss/vite';
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
-  plugins: [react(), tailwind()],
+  plugins: [react(), tailwind(), tsconfigPaths()],
 });


### PR DESCRIPTION
## 관련 이슈
#3 

## 작업 내용

모달 UI 및 동작을 재사용 가능하게 개선했습니다.  
각 모달은 공통 로직을 커스텀 훅과 `ModalOverlay` 컴포넌트를 통해 관리합니다.

### 1. 모달 관련 커스텀 훅 생성
- `useToggle()`: 모달 열림/닫힘 상태 관리
- `useOutsideClick()`: 모달 외부 클릭 시 닫기
- `useEscapeKey()`: Escape 키 입력 시 닫기

### 2. 모달별 액션 처리 방식
- `Alerts`, `ConfirmDialog`: `actions` prop으로 버튼 액션 처리
- `SimpleMenus`: `menus` prop으로 메뉴 액션 처리
- `SimpleDialog`: 단순 표시용, 액션 없음

```ts
export interface Action {
  label: string;
  onClick?: () => void;
}
```

### 3. 모달 스타일 관리
다음 파일에서 동적 스타일을 정의 및 적용합니다.
- styles/modal.css: 모달 레이아웃 및 애니메이션 정의
- modalClass.ts: 상태에 따른 동적 className 반환
- ModalOverlay.tsx: 공통 레이어 역할 (외부 클릭, Esc 키 처리, 애니메이션 적용)

모달의 상태 관리 및 사용 예시는 다음과 같습니다.
- App.tsx: useToggle 훅으로 모달 상태 관리
- 각 모달은 ModalOverlay로 감싸 공통 동작을 적용

### 4. 환경 설정 및 파일명 수정
- Vite 경로 별칭 설정: vite-tsconfig-paths 의존성 설치 및 typescript paths 설정하였습니다.
- ToggleMenus -> SimpleMenus 컴포넌트명 변경: useToggle의 리턴값에 중복이 발생하여 SimpleMenus로 명칭을 변경하였습니다.

## 참고
- [keydown event](https://developer.mozilla.org/en-US/docs/Web/API/Element/keydown_event)
- [vite-tsconfig-paths](https://www.npmjs.com/package/vite-tsconfig-paths)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 모달에 공통 열림/닫힘 제어(isModalOpen, closeModal) 도입, Esc 키·바깥 클릭으로 닫기 지원, SimpleMenus 추가 및 앱에 모달 트리거 버튼(삭제, 제목 선택, 위치 동의, 계정 선택, 알림 권한) 배치.
- Style
  - 모달 전용 CSS 분리(modal.css), 전환·스케일 애니메이션 및 UI 스타일 정리.
- Refactor
  - 모달 컴포넌트 API 일관화 및 모듈 재노출(바렐) 추가, ToggleMenus → SimpleMenus 교체.
- Chores
  - 경로 별칭(tsconfig) 설정 및 빌드 플러그인 추가(vite-tsconfig-paths), package.json devDependency 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->